### PR TITLE
Replaced call to deprecated mark_context_dirty.

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -48,5 +48,9 @@ function xmldb_block_mrbs_install() {
     assign_capability('block/mrbs:doublebook', CAP_ALLOW, $mrbsadminid, $context->id, true);
 
     // Clear any capability caches
-    mark_context_dirty($context->path);
+    if ($CFG->version < 2013111800) {
+        mark_context_dirty($context->path);
+    } else {
+        $context->mark_dirty();
+    }
 }


### PR DESCRIPTION
Method was deprecated at version 2013111800 so have added a check to choose between deprecated version and new version.
