### PR TITLE
PHP7.0 mktime compatibility

### DIFF
--- a/web/day.php
+++ b/web/day.php
@@ -80,8 +80,8 @@ print_header_mrbs($day, $month, $year, $area);
 //  0 => entering DST
 //  1 => leaving DST
 $dst_change = is_dst($month,$day,$year);
-$am7=mktime($morningstarts,$morningstarts_minutes,0,$month,$day,$year,is_dst($month,$day,$year,$morningstarts));
-$pm7=mktime($eveningends,$eveningends_minutes,0,$month,$day,$year,is_dst($month,$day,$year,$eveningends));
+$am7=mktime($morningstarts,$morningstarts_minutes,0,$month,$day,$year);
+$pm7=mktime($eveningends,$eveningends_minutes,0,$month,$day,$year);
 
 if ( $pview != 1 ) {
    echo "<table width=\"100%\"><tr><td width=\"40%\">";

--- a/web/edit_entry_handler.php
+++ b/web/edit_entry_handler.php
@@ -218,10 +218,10 @@ if($all_day)
     }
     else
     {
-        $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year, is_dst($month, $day  , $year));
+        $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year);
         $end_minutes = $eveningends_minutes + $morningstarts_minutes;
         ($eveningends_minutes > 59) ? $end_minutes += 60 : '';
-        $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year, is_dst($month, $day, $year));
+        $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year);
     }
 }
 else
@@ -238,8 +238,8 @@ else
       }
     }
 
-    $starttime = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour));
-    $endtime   = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour)) + ($units * $duration);
+    $starttime = mktime($hour, $minute, 0, $month, $day, $year);
+    $endtime   = mktime($hour, $minute, 0, $month, $day, $year) + ($units * $duration);
 
     // Round up the duration to the next whole resolution unit.
     // If they asked for 0 minutes, push that up to 1 resolution unit.

--- a/web/month.php
+++ b/web/month.php
@@ -93,11 +93,11 @@ for ($j = 1; $j<=$days_in_month; $j++) {
 	//  1 => leaving DST
 	$dst_change[$j] = is_dst($month, $j, $year);
     if (empty($enable_periods)) {
-		$midnight[$j] = mktime(0, 0, 0, $month, $j, $year, is_dst($month, $j, $year, 0));
-		$midnight_tonight[$j] = mktime(23, 59, 59, $month, $j, $year, is_dst($month, $j, $year, 23));
+		$midnight[$j] = mktime(0, 0, 0, $month, $j, $year);
+		$midnight_tonight[$j] = mktime(23, 59, 59, $month, $j, $year);
 	} else {
-		$midnight[$j] = mktime(12, 0, 0, $month, $j, $year, is_dst($month, $j, $year, 0));
-		$midnight_tonight[$j] = mktime(12, count($periods), 59, $month, $j, $year, is_dst($month, $j, $year, 23));
+		$midnight[$j] = mktime(12, 0, 0, $month, $j, $year);
+		$midnight_tonight[$j] = mktime(12, count($periods), 59, $month, $j, $year);
     }
 }
 

--- a/web/roomsearch_ss.php
+++ b/web/roomsearch_ss.php
@@ -94,10 +94,10 @@ $ampm = optional_param('ampm', null, PARAM_ALPHA);
         }
         else
         {
-            $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year, is_dst($month, $day  , $year));
+            $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year);
             $end_minutes = $eveningends_minutes + $morningstarts_minutes;
             ($eveningends_minutes > 59) ? $end_minutes += 60 : '';
-            $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year, is_dst($month, $day, $year));
+            $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year);
         }
     }
     else
@@ -114,8 +114,8 @@ $ampm = optional_param('ampm', null, PARAM_ALPHA);
           }
         }
 
-        $starttime = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour));
-        $endtime   = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour)) + ($units * $duration);
+        $starttime = mktime($hour, $minute, 0, $month, $day, $year);
+        $endtime   = mktime($hour, $minute, 0, $month, $day, $year) + ($units * $duration);
         // Round up the duration to the next whole resolution unit.
         // If they asked for 0 minutes, push that up to 1 resolution unit.
         $diff = $endtime - $starttime;

--- a/web/updatefreerooms.php
+++ b/web/updatefreerooms.php
@@ -89,10 +89,10 @@ if (!$area) {
         }
         else
         {
-            $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year, is_dst($month, $day  , $year));
+            $starttime = mktime($morningstarts, 0, 0, $month, $day  , $year);
             $end_minutes = $eveningends_minutes + $morningstarts_minutes;
             ($eveningends_minutes > 59) ? $end_minutes += 60 : '';
-            $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year, is_dst($month, $day, $year));
+            $endtime   = mktime($eveningends, $end_minutes, 0, $month, $day, $year);
         }
     }
     else
@@ -109,8 +109,8 @@ if (!$area) {
           }
         }
 
-        $starttime = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour));
-        $endtime   = mktime($hour, $minute, 0, $month, $day, $year, is_dst($month, $day, $year, $hour)) + ($units * $duration);
+        $starttime = mktime($hour, $minute, 0, $month, $day, $year);
+        $endtime   = mktime($hour, $minute, 0, $month, $day, $year) + ($units * $duration);
         // Round up the duration to the next whole resolution unit.
         // If they asked for 0 minutes, push that up to 1 resolution unit.
         $diff = $endtime - $starttime;

--- a/web/userweek.php
+++ b/web/userweek.php
@@ -119,8 +119,8 @@ for ($j = 0; $j<=($num_of_days-1); $j++) {
     //  0 => entering DST
     //  1 => leaving DST
     $dst_change[$j] = is_dst($month,$day+$j,$year);
-    $am7[$j]=mktime($morningstarts,$morningstarts_minutes,0,$month,$day+$j,$year,is_dst($month,$day+$j,$year,$morningstarts));
-    $pm7[$j]=mktime($eveningends,$eveningends_minutes,0,$month,$day+$j,$year,is_dst($month,$day+$j,$year,$eveningends));
+    $am7[$j]=mktime($morningstarts,$morningstarts_minutes,0,$month,$day+$j,$year);
+    $pm7[$j]=mktime($eveningends,$eveningends_minutes,0,$month,$day+$j,$year);
 }
 
 if ( $pview != 1 ) {

--- a/web/week.php
+++ b/web/week.php
@@ -102,8 +102,8 @@ for ($j = 0; $j<=($num_of_days-1); $j++) {
     //  0 => entering DST
     //  1 => leaving DST
     $dst_change[$j] = is_dst($month,$day+$j,$year);
-    $am7[$j]=mktime($morningstarts,$morningstarts_minutes,0,$month,$day+$j,$year,is_dst($month,$day+$j,$year,$morningstarts));
-    $pm7[$j]=mktime($eveningends,$eveningends_minutes,0,$month,$day+$j,$year,is_dst($month,$day+$j,$year,$eveningends));
+    $am7[$j]=mktime($morningstarts,$morningstarts_minutes,0,$month,$day+$j,$year);
+    $pm7[$j]=mktime($eveningends,$eveningends_minutes,0,$month,$day+$j,$year);
 }
 
 if ( $pview != 1 ) {


### PR DESCRIPTION
The is_dst parameter of mktime() has been removed in PHP 7.0.

Following change has been necessary:
`find . -type f -print0 | xargs -0 sed -r -i "s/mktime\((.*?), ?is_dst\(.*?\)\)/mktime\(\1\)/"`

After this patch, the plugin seems to be compatible with Moodle 3.1.