### PR TITLE
Fix get_all_user_name_fields() is deprecated

### DIFF
--- a/web/view_entry.php
+++ b/web/view_entry.php
@@ -75,7 +75,9 @@ if ($pview) {
 $PAGE->set_url($thisurl);
 require_login();
 
-$namefields = get_all_user_name_fields(true, 'u');
+$namefields = \core_user\fields::get_name_fields();
+$namefields = substr_replace($namefields, 'u.', 0, 0);
+$namefields = join(',', $namefields);
 if ($series) {
     $sql = "SELECT re.name,
             re.description,


### PR DESCRIPTION
On Moodle 4.*, a deprecation warning prohibits editing of reservations by the administrator.

The error message is "get_all_user_name_fields() is deprecated. Please use the \core_user\fields API instead". 

Simple internet search pointed me to a possible solution of this error at https://github.com/catalyst/moodle-mod_facetoface/pull/64/files which I adapted to block_mrbs. This fixes the given error.